### PR TITLE
Refactor Transformer Models & Extend Encoder-Decoder Support

### DIFF
--- a/bert_squeeze/assistants/configs/distil_hard.yaml
+++ b/bert_squeeze/assistants/configs/distil_hard.yaml
@@ -1,4 +1,4 @@
-bert_squeeze/assistants/configs/distil_hard.yaml general:
+general:
   debug: false
   do_train: true
   do_eval: false
@@ -31,7 +31,7 @@ train:
   weight_decay: 0.01
 
 model:
-  _target_: bert_squeeze.sequence_classification_distiller.SequenceClassificationDistiller
+  _target_: bert_squeeze.distillation.sequence_classification_distiller.SequenceClassificationDistiller
   teacher:
     _target_: transformers.models.auto.AutoModelForSequenceClassification.from_pretrained
     pretrained_model_name_or_path: "bert-base-uncased"

--- a/bert_squeeze/models/base_lt_module.py
+++ b/bert_squeeze/models/base_lt_module.py
@@ -1,6 +1,6 @@
 import logging
 from copy import deepcopy
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 import lightning.pytorch as pl
 import matplotlib.pyplot as plt
@@ -42,7 +42,6 @@ class BaseTransformerModule(pl.LightningModule):
         self.config = training_config
 
         self.pretrained_model = pretrained_model
-        self.model_config = None
 
         self.training_step_outputs = []
         self.test_step_outputs = []
@@ -459,9 +458,6 @@ class BaseSeq2SeqTransformerModule(BaseTransformerModule):
         super().__init__(training_config, pretrained_model, **kwargs)
         self._sanity_checks(training_config)
         self.task = task
-        self.model_config = AutoConfig.from_pretrained(
-            pretrained_model, task=task, output_hidden_states=False
-        )
 
         self._set_scorers()
         self._set_objective()

--- a/bert_squeeze/models/custom_transformers/__init__.py
+++ b/bert_squeeze/models/custom_transformers/__init__.py
@@ -1,3 +1,4 @@
 from .bert import CustomBertModel
+from .encoder_decoder import BaseEncoderDecoderModel
 from .fastbert import FastBertGraph
 from .theseus_bert import TheseusBertModel

--- a/bert_squeeze/models/custom_transformers/encoder_decoder.py
+++ b/bert_squeeze/models/custom_transformers/encoder_decoder.py
@@ -1,13 +1,16 @@
 from typing import Union
 
+import torch
 import torch.nn as nn
-from transformers import AutoModel
+from transformers import AutoModel, VisionEncoderDecoderModel
 
 
 class BaseEncoderDecoderModel(nn.Module):
     """
     A model that contains an encoder and a decoder, with support for loading from pre-trained transformer checkpoints.
     """
+
+    BASE_MODEL_CLASS = AutoModel
 
     def __init__(
         self,
@@ -34,7 +37,7 @@ class BaseEncoderDecoderModel(nn.Module):
 
         if model is not None:
             if isinstance(model, str):
-                model = AutoModel.from_pretrained(model)
+                model = self.BASE_MODEL_CLASS.from_pretrained(model)
 
             assert hasattr(model, "encoder") and hasattr(
                 model, "decoder"
@@ -42,9 +45,9 @@ class BaseEncoderDecoderModel(nn.Module):
             self.model = model
         else:
             if isinstance(encoder, str):
-                encoder = AutoModel.from_pretrained(encoder)
+                encoder = self.BASE_MODEL_CLASS.from_pretrained(encoder)
             if isinstance(decoder, str):
-                decoder = AutoModel.from_pretrained(decoder)
+                decoder = self.BASE_MODEL_CLASS.from_pretrained(decoder)
 
             self.model = nn.ModuleDict({"encoder": encoder, "decoder": decoder})
 
@@ -111,3 +114,23 @@ class BaseEncoderDecoderModel(nn.Module):
     def forward(self, *args, **kwargs):
         """"""
         raise NotImplementedError()
+
+
+class VisionEncoderDecoder(BaseEncoderDecoderModel):
+    """"""
+
+    BASE_MODEL_CLASS = VisionEncoderDecoderModel
+
+    def __init__(
+        self,
+        model: Union[str, nn.Module] = None,
+        encoder: Union[str, nn.Module] = None,
+        decoder: Union[str, nn.Module] = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(model, encoder, decoder, *args, **kwargs)
+
+    def forward(self, pixel_values: torch.Tensor, *args, **kwargs):
+        """"""
+        return self.model(pixel_values)

--- a/bert_squeeze/models/custom_transformers/encoder_decoder.py
+++ b/bert_squeeze/models/custom_transformers/encoder_decoder.py
@@ -1,0 +1,113 @@
+from typing import Union
+
+import torch.nn as nn
+from transformers import AutoModel
+
+
+class BaseEncoderDecoderModel(nn.Module):
+    """
+    A model that contains an encoder and a decoder, with support for loading from pre-trained transformer checkpoints.
+    """
+
+    def __init__(
+        self,
+        model: Union[str, nn.Module] = None,
+        encoder: Union[str, nn.Module] = None,
+        decoder: Union[str, nn.Module] = None,
+        *args,
+        **kwargs,
+    ):
+        """Initialize the EncoderDecoderModel with either a single model or separate encoder and decoder.
+
+        Args:
+            model (Union[str, nn.Module]): A string specifying the pre-trained model or an instance of a model
+                                           with encoder and decoder.
+            encoder (Union[str, nn.Module]): A string specifying the pre-trained encoder model or an instance
+                                             of an encoder.
+            decoder (Union[str, nn.Module]): A string specifying the pre-trained decoder model or an instance
+                                             of a decoder.
+        """
+        super().__init__(*args, **kwargs)
+        assert model is not None or (
+            encoder is not None and decoder is not None
+        ), "You need to provide either a model or an encoder and a decoder"
+
+        if model is not None:
+            if isinstance(model, str):
+                model = AutoModel.from_pretrained(model)
+
+            assert hasattr(model, "encoder") and hasattr(
+                model, "decoder"
+            ), "The model you provide must contain an encoder and a decoder module"
+            self.model = model
+        else:
+            if isinstance(encoder, str):
+                encoder = AutoModel.from_pretrained(encoder)
+            if isinstance(decoder, str):
+                decoder = AutoModel.from_pretrained(decoder)
+
+            self.model = nn.ModuleDict({"encoder": encoder, "decoder": decoder})
+
+    @property
+    def encoder(self) -> nn.Module:
+        """Returns the current encoder of the model."""
+        return self.model.encoder
+
+    @encoder.setter
+    def encoder(self, encoder: Union[str, nn.Module]) -> None:
+        """Sets a new encoder for the model.
+
+        Args:
+            encoder (Union[str, nn.Module]): A string specifying the pre-trained model or an instantiated model.
+        """
+        self.replace_encoder(encoder)
+
+    @property
+    def decoder(self) -> nn.Module:
+        """Returns the current decoder of the model."""
+        return self.model.decoder
+
+    @decoder.setter
+    def decoder(self, decoder: Union[str, nn.Module]) -> None:
+        """Sets a new decoder for the model.
+
+        Args:
+            decoder (Union[str, nn.Module]): A string specifying the pre-trained model or an instantiated model.
+        """
+        self.replace_decoder(decoder)
+
+    def replace_encoder(self, model: Union[str, nn.Module]) -> None:
+        """Replace the current encoder of the model with a new one.
+
+        Args:
+            model (Union[str, nn.Module]): A string specifying the pre-trained encoder model or an instance of a
+                                           model with an encoder module.
+        """
+        if isinstance(model, str):
+            encoder = AutoModel.from_pretrained(model)
+        else:
+            if hasattr(model, "encoder"):
+                encoder = model.encoder
+            else:
+                encoder = model
+        self.model.encoder = encoder
+
+    def replace_decoder(self, model: Union[str, nn.Module]) -> None:
+        """Replace the current decoder of the model with a new one.
+
+        Args:
+            model (Union[str, nn.Module]): A string specifying the pre-trained decoder model or an instance of a
+                                           model with a decoder module.
+        """
+        if isinstance(model, str):
+            decoder = AutoModel.from_pretrained(model)
+        else:
+            if hasattr(model, "decoder"):
+                decoder = model.decoder
+            else:
+                decoder = model
+        self.model.decoder = decoder
+
+    def forward(self, *args, **kwargs):
+        """"""
+        raise NotImplementedError()

--- a/bert_squeeze/models/custom_transformers/encoder_decoder.py
+++ b/bert_squeeze/models/custom_transformers/encoder_decoder.py
@@ -113,7 +113,11 @@ class BaseEncoderDecoderModel(nn.Module):
 
     def forward(self, *args, **kwargs):
         """"""
-        raise NotImplementedError()
+        return self.model(*args, **kwargs)
+
+    def generate(self, *args, **kwargs):
+        """"""
+        return self.model.generate(*args, **kwargs)
 
 
 class VisionEncoderDecoder(BaseEncoderDecoderModel):

--- a/bert_squeeze/models/lt_adapter.py
+++ b/bert_squeeze/models/lt_adapter.py
@@ -134,7 +134,6 @@ class LtAdapter(BaseSequenceClassificationTransformerModule):
         )
         return loss
 
-    @overrides
     def _build_model(self):
         """"""
         config = AutoConfig.from_pretrained(

--- a/bert_squeeze/models/lt_bert.py
+++ b/bert_squeeze/models/lt_bert.py
@@ -32,7 +32,6 @@ class LtSequenceClassificationCustomBert(BaseSequenceClassificationTransformerMo
         **kwargs,
     ):
         super().__init__(training_config, pretrained_model, num_labels, **kwargs)
-        self._build_model()
 
     @overrides
     def forward(
@@ -129,7 +128,6 @@ class LtSequenceClassificationCustomBert(BaseSequenceClassificationTransformerMo
         )
         return loss
 
-    @overrides
     def _build_model(self):
         """"""
         self.encoder = CustomBertModel.from_pretrained(self.pretrained_model)

--- a/bert_squeeze/models/lt_deebert.py
+++ b/bert_squeeze/models/lt_deebert.py
@@ -8,7 +8,6 @@ from omegaconf import DictConfig, ListConfig
 from overrides import overrides
 from torch.nn import CrossEntropyLoss
 
-from ..utils.errors import RampException
 from .base_lt_module import BaseSequenceClassificationTransformerModule
 from .custom_transformers.deebert import DeeBertModel
 
@@ -372,7 +371,6 @@ class LtDeeBert(BaseSequenceClassificationTransformerModule):
             )
         return loss
 
-    @overrides
     def _build_model(self):
         """"""
         self.bert = DeeBertModel(self.model_config)

--- a/bert_squeeze/models/lt_distilbert.py
+++ b/bert_squeeze/models/lt_distilbert.py
@@ -119,7 +119,6 @@ class LtCustomDistilBert(BaseSequenceClassificationTransformerModule):
         )
         return loss
 
-    @overrides
     def _build_model(self):
         """"""
         self.encoder = AutoModel.from_pretrained(self.pretrained_model)

--- a/bert_squeeze/models/lt_fastbert.py
+++ b/bert_squeeze/models/lt_fastbert.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from collections import defaultdict
-from typing import Dict, List, Tuple, Union
+from typing import List, Union
 
 import torch
 import torch.nn.functional as F
@@ -190,7 +190,6 @@ class LtFastBert(BaseSequenceClassificationTransformerModule):
         self.test_scorer.add(logits.cpu(), batch["labels"].cpu(), losses)
         self.test_step_outputs.append({"loss": losses.full_loss, "logits": logits.cpu()})
 
-    @overrides
     def _build_model(self):
         """"""
         self.embeddings = BertEmbeddings(self.model_config)

--- a/bert_squeeze/models/lt_t5.py
+++ b/bert_squeeze/models/lt_t5.py
@@ -1,12 +1,11 @@
-from typing import Union
+from typing import Optional, Union
 
 import lightning.pytorch as pl
 import numpy as np
 import torch
-from hydra.utils import instantiate
+import torch.nn as nn
 from omegaconf import DictConfig
-from overrides import overrides
-from transformers import AutoModelForSeq2SeqLM
+from transformers import T5ForConditionalGeneration
 from transformers.modeling_outputs import Seq2SeqLMOutput
 
 from bert_squeeze.models.base_lt_module import BaseSeq2SeqTransformerModule
@@ -23,26 +22,25 @@ class SimpleT5Model(BaseSeq2SeqTransformerModule):
             name of the pretrained model to use a backbone
         task (str):
             name of the task to perform
+        model (Optional[Union[pl.LightningModule, nn.Module]]):
+            optional instantiated model
         generate_kws (DictConfig):
              additional keywords to feed to the `.generate` method
     """
+
+    BASE_CLASS_MODEL = T5ForConditionalGeneration
 
     def __init__(
         self,
         training_config: DictConfig,
         pretrained_model: str,
         task: str,
-        model: pl.LightningModule = None,
+        model: Optional[Union[pl.LightningModule, nn.Module]] = None,
         generate_kwargs: DictConfig = None,
         **kwargs,
     ):
-        super().__init__(training_config, pretrained_model, task)
+        super().__init__(training_config, pretrained_model, task, model)
         self.generate_kwargs = generate_kwargs
-
-        if model is None:
-            self.model = AutoModelForSeq2SeqLM.from_pretrained(pretrained_model)
-        else:
-            self.model = model
 
     def forward(
         self, input_ids: torch.Tensor, attention_mask: torch.Tensor, labels: torch.Tensor

--- a/bert_squeeze/models/lt_theseus_bert.py
+++ b/bert_squeeze/models/lt_theseus_bert.py
@@ -142,7 +142,6 @@ class LtTheseusBert(BaseSequenceClassificationTransformerModule):
             {"loss": loss, "logits": logits.cpu(), "labels": batch["labels"].cpu()}
         )
 
-    @overrides
     def _build_model(self):
         """"""
         encoder = TheseusBertModel(AutoConfig.from_pretrained(self.pretrained_model))

--- a/tests/assistants/test_train_assistant.py
+++ b/tests/assistants/test_train_assistant.py
@@ -49,7 +49,7 @@ class TestTrainAssistant:
         )
         assert bert_assistant.general.num_labels == 6
         assert isinstance(bert_assistant.model, LtSequenceClassificationCustomBert)
-        assert bert_assistant.model.encoder.config._name_or_path == "bert-base-uncased"
+        assert bert_assistant.model.model.config._name_or_path == "bert-base-uncased"
         assert isinstance(bert_assistant.data, TransformerDataModule)
 
     def test_lstm_assistant(self):

--- a/tests/assistants/test_train_assistant.py
+++ b/tests/assistants/test_train_assistant.py
@@ -14,6 +14,7 @@ from bert_squeeze.models import (
     LtSequenceClassificationCustomBert,
     LtTheseusBert,
 )
+from bert_squeeze.models.custom_transformers import BaseEncoderDecoderModel
 
 
 @pytest.fixture
@@ -175,6 +176,41 @@ class TestSeq2SeqTraining:
         basic_trainer = Trainer(max_steps=4)
         basic_trainer.fit(
             model=model,
+            train_dataloaders=train_dataloader,
+            val_dataloaders=test_dataloader,
+        )
+
+    def test_t5_summarization_2(self):
+        """"""
+        adapter_assistant = TrainAssistant(
+            "t5",
+            data_kwargs={
+                "dataset_config": {
+                    "path": "kmfoda/booksum",
+                    "percent": 5,
+                    "target_col": "summary",
+                    "source_col": "chapter",
+                }
+            },
+            model_kwargs={
+                "model": {
+                    "_target_": "bert_squeeze.models.custom_transformers.BaseEncoderDecoderModel",
+                    "model": {
+                        "_target_": "transformers.models.t5.T5ForConditionalGeneration.from_pretrained",
+                        "pretrained_model_name_or_path": "t5-small",
+                    },
+                },
+                "pretrained_model": "t5-small",
+                "task": "summarization",
+            },
+        )
+
+        train_dataloader = adapter_assistant.data.train_dataloader()
+        test_dataloader = adapter_assistant.data.test_dataloader()
+
+        basic_trainer = Trainer(max_steps=4)
+        basic_trainer.fit(
+            model=adapter_assistant.model,
             train_dataloaders=train_dataloader,
             val_dataloaders=test_dataloader,
         )


### PR DESCRIPTION
## Description

This pull request introduces significant changes to the Transformer-based modules within the `bert_squeeze` package. Refactoring was performed to streamline model instantiation, and new features were added for better integration of encoder-decoder models, especially custom ones.

## Changelog

### Features
- Extend `BaseEncoderDecoderModel` to support `VisionEncoderDecoder`, allowing initialization from custom encoder and decoder or pre-trained vision models.
- Implement `EncoderDecoderModel` class to allow loading of pre-trained transformer checkpoints and provide methods for replacing encoder and decoder instances.

### Refactors
- Introduce `BASE_CLASS_MODEL` for better instantiation of Transformer-based modules and remove the need for `_build_model` method, hence simplifying the model architecture.
- Remove unnecessary `@overrides` decorators from model classes.
- Pass an optional instantiated model to `BaseTransformerModule` constructors for enhanced flexibility.
- Modified configuration files to point to the correct targets after structural changes.
- Simplify the `forward` method and add `generate` methods for `BaseEncoderDecoderModel`.
- Introduce an optional model parameter in the `SimpleT5Model` constructor for more streamlined instantiation.

### Test Updates
- Update existing tests to adhere to the new model structure.
- Add a new test case for the `T5` summarization with a custom `BaseEncoderDecoderModel`.