### PR TITLE
 refactor(seq2seq): improve Seq2Seq data collation and logging

### DIFF
--- a/bert_squeeze/data/modules/transformer_module.py
+++ b/bert_squeeze/data/modules/transformer_module.py
@@ -443,7 +443,13 @@ class Seq2SeqTransformerDataModule(BaseDataModule):
     def _collate_fn(self):
         """Helper function to merge a list of samples into a batch of Tensors"""
 
+        collator = DataCollatorForSeq2Seq(
+            tokenizer=self.tokenizer,
+            label_pad_token_id=-100,
+            return_tensors="pt",
+        )
+
         def _collate(examples):
-            return self.tokenizer.pad(examples, return_tensors="pt")
+            return collator(examples)
 
         return _collate

--- a/bert_squeeze/models/base_lt_module.py
+++ b/bert_squeeze/models/base_lt_module.py
@@ -302,15 +302,26 @@ class BaseTransformerModule(pl.LightningModule):
 
         It uses the evaluation scorer to log all the available losses and metrics
         """
-        table = self.valid_scorer.get_table()
+        eval_report = self.valid_scorer.to_dict()
+        try:
+            table = self.valid_scorer.get_table(eval_report)
+        except TypeError:
+            table = self.valid_scorer.get_table()
         self.logger.experiment.add_text("eval/report", table)
 
-        logging_loss = {
-            key: torch.stack(val).mean() for key, val in self.valid_scorer.losses.items()
-        }
-        self.log_dict({f"eval/loss_{key}": val for key, val in logging_loss.items()})
+        logging_loss = {}
+        for key, values in self.valid_scorer.losses.items():
+            if not values:
+                continue
+            first = values[0]
+            if isinstance(first, torch.Tensor):
+                logging_loss[key] = torch.stack(values).mean()
+            else:
+                logging_loss[key] = torch.tensor(np.mean(values))
 
-        eval_report = self.valid_scorer.to_dict()
+        if logging_loss:
+            self.log_dict({f"eval/loss_{key}": val for key, val in logging_loss.items()})
+
         for metric, value in eval_report.items():
             if isinstance(value, dict):
                 self.log_dict({f"eval/{metric}/{key}": v for key, v in value.items()})

--- a/bert_squeeze/models/base_lt_module.py
+++ b/bert_squeeze/models/base_lt_module.py
@@ -357,14 +357,18 @@ class BaseSequenceClassificationTransformerModule(BaseTransformerModule):
         scorer: Scorer = None,
         **kwargs,
     ):
-        super().__init__(training_config, pretrained_model, model, scorer, **kwargs)
-        self._sanity_checks(training_config)
-
         self.num_labels = num_labels
         self.model_config = AutoConfig.from_pretrained(
             pretrained_model, num_labels=num_labels
         )
 
+        if model is None:
+            model = self.BASE_CLASS_MODEL.from_pretrained(
+                pretrained_model, config=self.model_config
+            )
+
+        super().__init__(training_config, pretrained_model, model, scorer, **kwargs)
+        self._sanity_checks(training_config)
         self._set_objective()
 
     def on_validation_epoch_end(self):
@@ -426,7 +430,7 @@ class BaseSequenceClassificationTransformerModule(BaseTransformerModule):
                 helper object to compute performance metrics during training
         """
         if scorer is None:
-            scorer = BaseSequenceClassificationScorer(self.num_labels)
+            scorer = BaseSequenceClassificationScorer(list(range(self.num_labels)))
 
         self.scorer = deepcopy(scorer)
         self.valid_scorer = deepcopy(scorer)

--- a/tests/data/modules/test_seq2seq_transformer_module_collate.py
+++ b/tests/data/modules/test_seq2seq_transformer_module_collate.py
@@ -1,0 +1,71 @@
+import pytest
+from omegaconf import OmegaConf
+
+from bert_squeeze.data.modules.transformer_module import Seq2SeqTransformerDataModule
+
+
+class _DummyTokenizer:
+    name_or_path = "t5-small"
+    pad_token_id = 0
+    padding_side = "right"
+    model_input_names = ["input_ids", "attention_mask"]
+
+    def pad(
+        self,
+        features,
+        padding=True,
+        max_length=None,
+        pad_to_multiple_of=None,
+        return_tensors=None,
+        **kwargs,
+    ):
+        max_len = max(len(feature["input_ids"]) for feature in features)
+        input_ids = []
+        attention_mask = []
+        for feature in features:
+            ids = list(feature["input_ids"])
+            mask = list(feature["attention_mask"])
+            pad_len = max_len - len(ids)
+            input_ids.append(ids + [self.pad_token_id] * pad_len)
+            attention_mask.append(mask + [0] * pad_len)
+
+        import torch
+
+        return {
+            "input_ids": torch.tensor(input_ids, dtype=torch.long),
+            "attention_mask": torch.tensor(attention_mask, dtype=torch.long),
+        }
+
+
+@pytest.fixture(autouse=True)
+def mock_tokenizer(monkeypatch):
+    monkeypatch.setattr(
+        "bert_squeeze.data.modules.transformer_module.AutoTokenizer",
+        type(
+            "MockTokenizer", (), {"from_pretrained": lambda *_, **__: _DummyTokenizer()}
+        ),
+    )
+
+
+def test_collate_pads_labels_with_ignore_index():
+    config = OmegaConf.create(
+        {
+            "source_col": "source",
+            "target_col": "target",
+            "path": "dummy",
+        }
+    )
+    module = Seq2SeqTransformerDataModule(
+        config, tokenizer_name="t5-small", max_target_length=8, max_source_length=8
+    )
+    collate = module._collate_fn()
+
+    batch = collate(
+        [
+            {"input_ids": [1, 2, 3], "attention_mask": [1, 1, 1], "labels": [4, 5]},
+            {"input_ids": [6], "attention_mask": [1], "labels": [7, 8, 9]},
+        ]
+    )
+
+    assert batch["labels"].shape == (2, 3)
+    assert batch["labels"][0, 2].item() == -100

--- a/tests/test_base_lt_module.py
+++ b/tests/test_base_lt_module.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+
+import torch.nn as nn
+from omegaconf import OmegaConf
+
+import bert_squeeze.models.base_lt_module as base_lt_module
+from bert_squeeze.models.base_lt_module import BaseSequenceClassificationTransformerModule
+
+
+class _DummyConfig:
+    def __init__(self, num_labels: int):
+        self.num_labels = num_labels
+
+
+class _DummyModel(nn.Module):
+    def __init__(self, num_labels: int):
+        super().__init__()
+        self.config = SimpleNamespace(num_labels=num_labels)
+
+
+def test_base_sequence_classification_transformer_module_default_scorer(monkeypatch):
+    def _fake_from_pretrained(*args, **kwargs):
+        return _DummyConfig(num_labels=kwargs["num_labels"])
+
+    monkeypatch.setattr(
+        base_lt_module.AutoConfig, "from_pretrained", _fake_from_pretrained
+    )
+
+    training_config = OmegaConf.create(
+        {
+            "logging_steps": 2,
+            "accumulation_steps": 1,
+            "objective": "ce",
+            "lr_scheduler": False,
+        }
+    )
+
+    module = BaseSequenceClassificationTransformerModule(
+        training_config=training_config,
+        pretrained_model="dummy",
+        num_labels=3,
+        model=_DummyModel(num_labels=3),
+        scorer=None,
+    )
+
+    assert module.scorer.labels == [0, 1, 2]
+    assert module.scorer.n_labels == 3
+    assert module.scorer is not module.valid_scorer
+    assert module.scorer is not module.test_scorer

--- a/tests/utils/scorers/test_lm_scorer.py
+++ b/tests/utils/scorers/test_lm_scorer.py
@@ -1,0 +1,32 @@
+import math
+
+import pytest
+import torch
+
+from bert_squeeze.utils.scorers.lm_scorer import LMScorer, SummarizationScorer
+from bert_squeeze.utils.types import DistillationLoss
+
+
+def test_lm_scorer_supports_loss_only():
+    scorer = LMScorer(tokenizer_name=None, do_mismatch=True)
+    scorer.add(loss=torch.tensor(1.0))
+
+    assert len(scorer.losses["global"]) == 1
+    assert isinstance(scorer.losses["global"][0], torch.Tensor)
+    assert scorer.perplexity == pytest.approx(math.e, rel=1e-6)
+
+
+def test_lm_scorer_supports_distillation_loss():
+    scorer = LMScorer(tokenizer_name=None, do_mismatch=False)
+    loss = DistillationLoss(
+        kd_loss=torch.tensor(0.0),
+        objective=torch.tensor(0.0),
+        full_loss=torch.tensor(2.0),
+    )
+    scorer.add(loss=loss)
+    assert scorer.perplexity == pytest.approx(math.exp(2.0), rel=1e-6)
+
+
+def test_summarization_scorer_table_formats_scalars():
+    table = SummarizationScorer.get_table({"rouge1": 12.34})
+    assert "rouge1" in table


### PR DESCRIPTION
## Description
Improves Seq2Seq data handling and logging robustness. Replaces manual tokenizer padding with `DataCollatorForSeq2Seq` to properly handle label padding with ignore index (-100), preventing labels from being padded with the tokenizer's pad token. Refactors evaluation logging to support both tensor and non-tensor values (e.g., `DistillationLoss` objects), and restructures model initialization order to ensure models are properly configured before calling parent constructors. Also fixes scorer initialization to use label lists instead of integers.

## Risk
Low risk - changes improve correctness and robustness. The data collation change ensures labels are properly masked during training. Model initialization order change ensures proper configuration but should be tested across different model types.

## Tests
Comprehensive unit tests added:
- `test_collate_pads_labels_with_ignore_index`: validates label padding with -100
- `test_lm_scorer_supports_loss_only` and `test_lm_scorer_supports_distillation_loss`: validate LMScorer handles both tensor and DistillationLoss
- `test_base_sequence_classification_transformer_module_default_scorer`: validates correct scorer initialization
